### PR TITLE
chore: update Sumo Logic Terraform Provider to 2.28.3

### DIFF
--- a/monitor_packages/ActiveMQ/versions.tf
+++ b/monitor_packages/ActiveMQ/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     sumologic = {
-      version = "~> 2.18.0"
+      version = ">= 2.28.3, < 3.0.0"
       source = "SumoLogic/sumologic"
     }
   }

--- a/monitor_packages/ApacheTomcat/versions.tf
+++ b/monitor_packages/ApacheTomcat/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     sumologic = {
-      version = "~> 2.18.0"
+      version = ">= 2.28.3, < 3.0.0"
       source = "SumoLogic/sumologic"
     }
   }

--- a/monitor_packages/Cassandra/versions.tf
+++ b/monitor_packages/Cassandra/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     sumologic = {
-      version = "~> 2.18.0"
+      version = ">= 2.28.3, < 3.0.0"
       source = "SumoLogic/sumologic"
     }
   }

--- a/monitor_packages/Couchbase/versions.tf
+++ b/monitor_packages/Couchbase/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     sumologic = {
-      version = "~> 2.18.0"
+      version = ">= 2.28.3, < 3.0.0"
       source = "SumoLogic/sumologic"
     }
   }

--- a/monitor_packages/Elasticsearch/versions.tf
+++ b/monitor_packages/Elasticsearch/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     sumologic = {
-      version = "~> 2.18.0"
+      version = ">= 2.28.3, < 3.0.0"
       source = "SumoLogic/sumologic"
     }
   }

--- a/monitor_packages/IIS/versions.tf
+++ b/monitor_packages/IIS/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     sumologic = {
-      version = "~> 2.18.0"
+      version = ">= 2.28.3, < 3.0.0"
       source = "SumoLogic/sumologic"
     }
   }

--- a/monitor_packages/Kafka/versions.tf
+++ b/monitor_packages/Kafka/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     sumologic = {
-      version = "~> 2.18.0"
+      version = ">= 2.28.3, < 3.0.0"
       source = "SumoLogic/sumologic"
     }
   }

--- a/monitor_packages/MariaDB/versions.tf
+++ b/monitor_packages/MariaDB/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     sumologic = {
-      version = "~> 2.18.0"
+      version = ">= 2.28.3, < 3.0.0"
       source = "SumoLogic/sumologic"
     }
   }

--- a/monitor_packages/Memcached/versions.tf
+++ b/monitor_packages/Memcached/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     sumologic = {
-      version = "~> 2.18.0"
+      version = ">= 2.28.3, < 3.0.0"
       source = "SumoLogic/sumologic"
     }
   }

--- a/monitor_packages/MongoDB/versions.tf
+++ b/monitor_packages/MongoDB/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     sumologic = {
-      version = "~> 2.18.0"
+      version = ">= 2.28.3, < 3.0.0"
       source = "SumoLogic/sumologic"
     }
   }

--- a/monitor_packages/Oracle/versions.tf
+++ b/monitor_packages/Oracle/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     sumologic = {
-      version = "~> 2.18.0"
+      version = ">= 2.28.3, < 3.0.0"
       source = "SumoLogic/sumologic"
     }
   }

--- a/monitor_packages/RabbitMQ/versions.tf
+++ b/monitor_packages/RabbitMQ/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     sumologic = {
-      version = "~> 2.18.0"
+      version = ">= 2.28.3, < 3.0.0"
       source  = "SumoLogic/sumologic"
     }
   }

--- a/monitor_packages/SQLServer/versions.tf
+++ b/monitor_packages/SQLServer/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     sumologic = {
-      version = "~> 2.18.0"
+      version = ">= 2.28.3, < 3.0.0"
       source = "SumoLogic/sumologic"
     }
   }

--- a/monitor_packages/SquidProxy/versions.tf
+++ b/monitor_packages/SquidProxy/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     sumologic = {
-      version = "~> 2.18.0"
+      version = ">= 2.28.3, < 3.0.0"
       source = "SumoLogic/sumologic"
     }
   }

--- a/monitor_packages/Varnish/versions.tf
+++ b/monitor_packages/Varnish/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     sumologic = {
-      version = "~> 2.18.0"
+      version = ">= 2.28.3, < 3.0.0"
       source = "SumoLogic/sumologic"
     }
   }

--- a/monitor_packages/apache/versions.tf
+++ b/monitor_packages/apache/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     sumologic = {
-      version = "~> 2.18.0"
+      version = ">= 2.28.3, < 3.0.0"
       source = "SumoLogic/sumologic"
     }
   }

--- a/monitor_packages/haproxy/versions.tf
+++ b/monitor_packages/haproxy/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     sumologic = {
-      version = "~> 2.18.0"
+      version = ">= 2.28.3, < 3.0.0"
       source = "SumoLogic/sumologic"
     }
   }

--- a/monitor_packages/host_process_metrics/versions.tf
+++ b/monitor_packages/host_process_metrics/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     sumologic = {
-      version = "~> 2.18.0"
+      version = ">= 2.28.3, < 3.0.0"
       source = "SumoLogic/sumologic"
     }
   }

--- a/monitor_packages/http_response/versions.tf
+++ b/monitor_packages/http_response/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     sumologic = {
-      version = "~> 2.18.0"
+      version = ">= 2.28.3, < 3.0.0"
       source = "SumoLogic/sumologic"
     }
   }

--- a/monitor_packages/kubernetes/versions.tf
+++ b/monitor_packages/kubernetes/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     sumologic = {
-      version = "~> 2.18.0"
+      version = ">= 2.28.3, < 3.0.0"
       source = "SumoLogic/sumologic"
     }
   }

--- a/monitor_packages/mysql/versions.tf
+++ b/monitor_packages/mysql/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     sumologic = {
-      version = "~> 2.18.0"
+      version = ">= 2.28.3, < 3.0.0"
       source = "SumoLogic/sumologic"
     }
   }

--- a/monitor_packages/nginx-ingress/versions.tf
+++ b/monitor_packages/nginx-ingress/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     sumologic = {
-      version = "~> 2.18.0"
+      version = ">= 2.28.3, < 3.0.0"
       source = "SumoLogic/sumologic"
     }
   }

--- a/monitor_packages/nginx-plus-ingress/versions.tf
+++ b/monitor_packages/nginx-plus-ingress/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     sumologic = {
-      version = "~> 2.18.0"
+      version = ">= 2.28.3, < 3.0.0"
       source = "SumoLogic/sumologic"
     }
   }

--- a/monitor_packages/nginx-plus/versions.tf
+++ b/monitor_packages/nginx-plus/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     sumologic = {
-      version = "~> 2.18.0"
+      version = ">= 2.28.3, < 3.0.0"
       source = "SumoLogic/sumologic"
     }
   }

--- a/monitor_packages/nginx/versions.tf
+++ b/monitor_packages/nginx/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     sumologic = {
-      version = "~> 2.18.0"
+      version = ">= 2.28.3, < 3.0.0"
       source = "SumoLogic/sumologic"
     }
   }

--- a/monitor_packages/postgresql/versions.tf
+++ b/monitor_packages/postgresql/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     sumologic = {
-      version = "~> 2.18.0"
+      version = ">= 2.28.3, < 3.0.0"
       source = "SumoLogic/sumologic"
     }
   }

--- a/monitor_packages/redis/versions.tf
+++ b/monitor_packages/redis/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     sumologic = {
-      version = "~> 2.18.0"
+      version = ">= 2.28.3, < 3.0.0"
       source = "SumoLogic/sumologic"
     }
   }


### PR DESCRIPTION
This is needed to fix vulnerabilities, see https://github.com/SumoLogic/terraform-provider-sumologic/issues/602.