### PR TITLE
chore(kubernetes): update Sumo Logic Terraform Provider to 2.28.3

### DIFF
--- a/monitor_packages/kubernetes/versions.tf
+++ b/monitor_packages/kubernetes/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     sumologic = {
-      version = "~> 2.18.0"
+      version = ">= 2.28.3, < 3.0.0"
       source = "SumoLogic/sumologic"
     }
   }


### PR DESCRIPTION
This is needed to fix vulnerabilities, see https://github.com/SumoLogic/terraform-provider-sumologic/issues/602.

This change replaces https://github.com/SumoLogic/terraform-sumologic-sumo-logic-monitor/pull/69 to limit the scope and the risk of breaking some modules.