### PR TITLE
chore: update sumologic provider to 2.31.0

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     sumologic = {
-      version = ">= 2.28.3, < 3.0.0"
+      version = ">= 2.31.0, < 3.0.0"
       source = "SumoLogic/sumologic"
     }
   }


### PR DESCRIPTION
Upgrade minimal version of Sumo Logic Terraform provider to 2.31.0