### PR TITLE
Add tags argument to monitor resource

### DIFF
--- a/inputs.tf
+++ b/inputs.tf
@@ -50,6 +50,12 @@ variable "queries" {
   default     = null
 }
 
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "A map defining tag keys and tag values for the Monitor."
+}
+
 variable "triggers" {
   type        = list(object(
                 {

--- a/main.tf
+++ b/main.tf
@@ -44,6 +44,7 @@ resource "sumologic_monitor" "tf_monitor" {
   group_notifications = var.group_notifications
   slo_id = var.monitor_slo_id
   evaluation_delay = var.monitor_evaluation_delay
+  tags = var.tags
   
 
   dynamic "queries" {


### PR DESCRIPTION
I checked the 2.31.x docs for the monitor resource on hashicorp's registry site and `tags` is shown as a supported argument. https://registry.terraform.io/providers/SumoLogic/sumologic/2.31.5/docs/resources/monitor